### PR TITLE
Fix pgp server link

### DIFF
--- a/site/pages/install.md
+++ b/site/pages/install.md
@@ -145,7 +145,7 @@ Welcome to the KISS package manager! These two commands are how individual packa
 
 ### Import my (*[Dylan Araps](/pages/team)*) key
 
-If the GNU keyserver fails on your network, you can try an alternative mirror ([pgp.mit.edu](pgp.mit.edu) for example).
+If the GNU keyserver fails on your network, you can try an alternative mirror ([pgp.mit.edu](http://pgp.mit.edu) for example).
 
 ```
 # Import my public key.


### PR DESCRIPTION
The link used to redirect [here](https://getkiss.org/pages/pgp.mit.edu) instead of the proper [pgp.mit](http://pgp.mit.edu).