### PR TITLE
Fix interpretation of '<' character as an HTML tag

### DIFF
--- a/make
+++ b/make
@@ -21,6 +21,9 @@ txt2html() {
     sed -E "s|^( *)\[([0-9\.]*)\]|\1<span id=\2>[\2]</span>|g" |
     sed -E "s|([^\"#])\[([0-9\.]*)\]|\1<a href=#\2>[\2]</a>|g" |
 
+    # Convert '<' to '&lt;'.
+    sed -E "s|<repo_url>|\&lt;repo_url>|g" |
+
     # Insert the page into the template.
     sed -E '/%%CONTENT%%/r /dev/stdin' template.html |
     sed -E '/%%CONTENT%%/d' |


### PR DESCRIPTION
In the 'site/package-manager.txt' file, the string '<repo_url>' was being interpreted as an HTML tag, and thus not being displayed.  This change replaces the '<' character with '\&lt;' in the 'make' file so that it will be correctly displayed.