### PR TITLE
Fix setting of title

### DIFF
--- a/make
+++ b/make
@@ -59,7 +59,7 @@ wiki_nav() {
 }
 
 page() {
-    pp=${page%/*} title=${page##*/} title=${title%%.txt}
+    pp=${page%/*}; title=${page##*/}; title=${title%%.txt}
 
     mkdir -p "docs/$pp"
 


### PR DESCRIPTION
At least on (Free|Open)BSD, the line `pp=... title=... title=...` sets 'title' to an empty string.  This pr just adds semicolons between the variable declarations to fix that issue.