### PR TITLE
sort dependencys by wether they are required

### DIFF
--- a/site/answers.txt
+++ b/site/answers.txt
@@ -13,7 +13,7 @@ ________________________________________________________________________________
   * What Does "KISS" Mean? ............................................... [002]
 
 * Software ............................................................... [003]
-  * Why Is SOFTWARE Not Packaged? ........................................ [004]
+  * Why Is X piece of SOFTWARE Not Packaged? ............................. [004]
   * Can The Distribution Package SOFTWARE For Me? ........................ [005]
   * Does DRM Work In Web Browsers? ....................................... [006]
 
@@ -45,7 +45,7 @@ ________________________________________________________________________________
 ________________________________________________________________________________
 
 
---[004] Why Is SOFTWARE Not Packaged -------------------------------------------
+--[004] Why Is X piece of SOFTWARE Not Packaged?--------------------------------
 
   The distribution provides users with an extensible base (including a modern
   web browser and media player). Any software that goes beyond this goal is not

--- a/site/wiki/package-manager.txt
+++ b/site/wiki/package-manager.txt
@@ -51,10 +51,10 @@ ________________________________________________________________________________
 | POSIX utilities       | N/A                                       | Yes      |
 | git                   | Remote repositories and git sources       | Yes [1]  |
 | curl                  | Source downloads                          | Yes      |
-| gnupg1 or gnupg2      | Repository signing                        | No       |
 | openssl               | Checksums                                 | Yes [2]  |
 | tar                   | Sources, packages, etc                    | Yes [3]  |
 | gzip, bzip2, xz, zstd | Tarball compression                       | Yes [4]  |
+| gnupg1 or gnupg2      | Repository signing                        | No       |
 | su, sudo, doas, ssu   | Privilege escalation                      | No [5]   |
 | ldd                   | Dependency Fixer                          | No [6]   |
 | readelf               | Dependency Fixer (better edition)         | No [6]   |


### PR DESCRIPTION
This improves readability if people only want to install required dependencys